### PR TITLE
Allow custom filter classes and fix multiple filter annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
-/vendor/
-phpunit.xml
+# Ingore common cruft
+.DS_STORE
+coverage
+
+# Ignore IDE settings
+/.idea/
+/atlassian-ide-plugin.xml
+
+# Ignore potentially sensitive phpunit file
+/phpunit.xml
+
+# Ignore composer generated files
+composer.phar
 composer.lock
+composer-test.lock
+/vendor/

--- a/Annotation/FilterAnnotation.php
+++ b/Annotation/FilterAnnotation.php
@@ -77,7 +77,7 @@ final class FilterAnnotation implements Annotation
             throw new \InvalidArgumentException('Filter must be string');
         }
 
-        if ($filter && strpos($filter, 'Zend\Filter') === false) {
+        if ($filter && strpos($filter, '\\') === false) {
             $filter = 'Zend\Filter\\'.$filter;
         }
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ class User
     /**
      * @Filter("StripTags")
      * @Filter("StringTrim")
+     * @Filter("AppBundle\Filter\SanitizeAbout")
      * @var string
      */
     protected $about;

--- a/Service/Filter.php
+++ b/Service/Filter.php
@@ -49,15 +49,15 @@ class Filter
 
         $reflectionClass = ClassUtils::newReflectionClass(get_class($object));
         foreach ($reflectionClass->getProperties() as $property) {
-            $filterAnnotation = $this->annotationReader->getPropertyAnnotation($property, FilterAnnotation::class);
+            foreach ($this->annotationReader->getPropertyAnnotations($property) as $annotation) {
+                if ($annotation instanceof FilterAnnotation) {
+                    $property->setAccessible(true);
 
-            if ($filterAnnotation instanceof FilterAnnotation) {
-                $property->setAccessible(true);
-
-                if ($value = $property->getValue($object)) {
-                    $filter = $filterAnnotation->getFilter();
-                    $options = $filterAnnotation->getOptions();
-                    $property->setValue($object, $this->getZendInstance($filter, $options)->filter($value));
+                    if ($value = $property->getValue($object)) {
+                        $filter  = $annotation->getFilter();
+                        $options = $annotation->getOptions();
+                        $property->setValue($object, $this->getZendInstance($filter, $options)->filter($value));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, only a single `@Filter` annotation was possible. If you added multiple `@Filter` annotations to the same entity property, only the first one was honored, the others got ignored. You might also add a test for this.
Next to the default Zend\Filter classes, we should also allow our own custom app/bundle specific filter classes that extend Zend\Filter\AbstractFilter.
