### PR TITLE
Fix travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ allow_failures:
 
 before_script:
   - composer self-update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - composer install --dev --prefer-dist --no-interaction
 
 script:


### PR DESCRIPTION
Currently all builds are made for the latest Symfony version. As you can see https://travis-ci.org/sergeyfedotov/FilterBundle/builds/126106446 builds are now failed for the Symfony 2.7. They are failed because Symfony 2.7 doesn't support a fully qualified class name as the form type name.
