### PR TITLE
Use interface for avoid error with instance passed

### DIFF
--- a/Service/Filter.php
+++ b/Service/Filter.php
@@ -3,7 +3,7 @@
 namespace Bukashk0zzz\FilterBundle\Service;
 
 use Bukashk0zzz\FilterBundle\Annotation\FilterAnnotation;
-use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Util\ClassUtils;
 use Laminas\Filter\AbstractFilter;
 use Laminas\Filter\FilterInterface;
@@ -14,16 +14,16 @@ use Laminas\Filter\FilterInterface;
 class Filter
 {
     /**
-     * @var CachedReader Cached annotation reader
+     * @var Reader Cached annotation reader
      */
     protected $annotationReader;
 
     /**
      * Filter constructor.
      *
-     * @param CachedReader $annotationReader
+     * @param Reader $annotationReader
      */
-    public function __construct(CachedReader $annotationReader)
+    public function __construct(Reader $annotationReader)
     {
         $this->annotationReader = $annotationReader;
     }


### PR DESCRIPTION
Avoid this error:
`Argument 1 passed to Bukashk0zzz\FilterBundle\Service\Filter::__construct() must be an instance of Doctrine\Common\Annotations\CachedReader, instance of Doctrine\Common\Annotations\PsrCachedReader
!!     given` 

Appeared when upgrading components to Symfony 4.4.24