### PR TITLE
Added support for PHP 8.0 attributes

### DIFF
--- a/Annotation/FilterAnnotation.php
+++ b/Annotation/FilterAnnotation.php
@@ -4,6 +4,7 @@ namespace Bukashk0zzz\FilterBundle\Annotation;
 
 use Attribute;
 use Doctrine\ORM\Mapping\Annotation;
+use Doctrine\ORM\Mapping\MappingAttribute;
 
 /**
  * FilterAnnotation
@@ -12,7 +13,7 @@ use Doctrine\ORM\Mapping\Annotation;
  * @Target({"PROPERTY", "METHOD"})
  */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
-final class FilterAnnotation implements Annotation
+final class FilterAnnotation implements MappingAttribute
 {
     /**
      * @var string LaminasFilter name

--- a/Annotation/FilterAnnotation.php
+++ b/Annotation/FilterAnnotation.php
@@ -2,6 +2,7 @@
 
 namespace Bukashk0zzz\FilterBundle\Annotation;
 
+use Attribute;
 use Doctrine\ORM\Mapping\Annotation;
 
 /**
@@ -10,6 +11,7 @@ use Doctrine\ORM\Mapping\Annotation;
  * @Annotation()
  * @Target({"PROPERTY", "METHOD"})
  */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class FilterAnnotation implements Annotation
 {
     /**

--- a/Service/Filter.php
+++ b/Service/Filter.php
@@ -5,8 +5,8 @@ namespace Bukashk0zzz\FilterBundle\Service;
 use Bukashk0zzz\FilterBundle\Annotation\FilterAnnotation;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Util\ClassUtils;
-use Laminas\Filter\AbstractFilter;
-use Laminas\Filter\FilterInterface;
+use Laminas\Filter\FilterChain;
+use ReflectionProperty;
 
 /**
  * Class Filter
@@ -40,50 +40,54 @@ class Filter
         $reflectionClass = ClassUtils::newReflectionClass(\get_class($object));
 
         foreach ($reflectionClass->getProperties() as $property) {
-            foreach ($this->annotationReader->getPropertyAnnotations($property) as $annotation) {
-                if (!($annotation instanceof FilterAnnotation)) {
-                    continue;
-                }
+            $attributes = $this->getAttributes($property);
 
-                $property->setAccessible(true);
-                $value = $property->getValue($object);
-
-                if (!$value) {
-                    continue;
-                }
-
-                $filter = $annotation->getFilter();
-                $options = $annotation->getOptions();
-                $property->setValue($object, $this->getLaminasInstance($filter, $options)->filter($value));
+            if (empty($attributes)) {
+                continue;
             }
+
+            $property->setAccessible(true);
+            $value = $property->getValue($object);
+
+            if (empty($value)) {
+                continue;
+            }
+
+            $filter = new FilterChain();
+            foreach($attributes as $attribute) {
+                $filter->attachByName($attribute->getFilter(), $attribute->getOptions());
+            }
+
+            $property->setValue($object, $filter->filter($value));
         }
     }
 
     /**
-     * @param string            $class
-     * @param array<mixed>|null $options
+     * Get Annotations of PHP Attributes.
      *
-     * @return \Laminas\Filter\FilterInterface
+     * @return array<FilterAnnotation>
      */
-    protected function getLaminasInstance(string $class, ?array $options): FilterInterface
+    private function getAttributes(ReflectionProperty $property): array
     {
-        /** @var AbstractFilter $filter */
-        $filter = new $class();
+        $annotations = $this->annotationReader->getPropertyAnnotations($property);
 
-        $abstractFilterClass = AbstractFilter::class;
-
-        if (!$filter instanceof $abstractFilterClass) {
-            throw new \InvalidArgumentException("Filter class must extend $abstractFilterClass: $class");
-        }
-
-        try {
-            if ($options !== null && \count($options) !== 0) {
-                $filter->setOptions($options);
+        $attributes = [];
+        foreach($annotations as $annotation) {
+            if ($annotation instanceof FilterAnnotation) {
+                $attributes[] = $annotation;
             }
-
-            return $filter;
-        } catch (\Throwable $e) {
-            return new $class($options);
         }
+
+        // If we get an empty array with the annotations, we try PHP Attributes
+        if (\PHP_VERSION_ID > 80000 && empty($attributes)) {
+            $attrs = $property->getAttributes(FilterAnnotation::class);
+
+            $attributes = [];
+            foreach($attrs as $attr) {
+                $attributes[] = $attr->newInstance();
+            }
+        }
+
+        return $attributes;
     }
 }


### PR DESCRIPTION
I add support for PHP 8.0 attributes

In `Bukashk0zzz\FilterBundle\Service\Filter` method `filterEntity` I made the following changes:

- Create a private method `getAttributes` for get Doctrine annotations or PHP Attributes. If find Annotations not search for PHP Attributes.
- Deleted method `getLaminasInstance` now use `Laminas\Filter\FilterChain` for apply all filters

> Notes:
For use new PHP Attributes use:

```php
<?php
namespace AppBundle\Entity;

use Bukashk0zzz\FilterBundle\Annotation\FilterAnnotation as Filter;

/**
 * User Entity
 */
class User
{
    /**
     * @var string
     */
    #[Filter(parameters: [
        'filter' => 'StripTags',
        'options' => ['allowTags' => 'br']
    ])]
    #[Filter(parameters: ['filter' => 'StringTrim'])]
    #[Filter(parameters: ['filter' => 'StripNewlines'])]
    protected $name;

    /**
     * @var string
     */
    #[Filter(parameters: ['filter' => 'StripTags'])]
    #[Filter(parameters: ['filter' => 'StringTrim'])]
    #[Filter(parameters: ['filter' => 'AppBundle\Filter\MyCustomFilter'])]
    protected $about;
}
}
```